### PR TITLE
Fix details field formmaker issue

### DIFF
--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -109,11 +109,6 @@ class Product extends QuarxModel
         return false;
     }
 
-    public function details()
-    {
-        return app(ProductService::class)->productDetails($this);
-    }
-
     public function detailsBtn($class = '')
     {
         return app(ProductService::class)->productDetailsBtn($this, $class);


### PR DESCRIPTION
There appears to be an old (I think) function which, because it matches the name of the "details" column, confuses the Laracogs FormMaker to the point where details are getting erased on every save. This means that product details get erased on every update.