### PR TITLE
Update CurrencyService.php

### DIFF
--- a/src/Services/CurrencyService.php
+++ b/src/Services/CurrencyService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Grafite\Commerce\Models;
+namespace Grafite\Commerce\Services;
 
 class Currency
 {


### PR DESCRIPTION
Fix namespace to prevent the Warning: Ambiguous class resolution, "Grafite\Commerce\Models\Currency" was found in both ...