### PR TITLE
CMS package doesn't support cms.db-prefix for the table user_meta

### DIFF
--- a/src/Migrations/2016_01_29_061206_create_customer_profiles_table.php
+++ b/src/Migrations/2016_01_29_061206_create_customer_profiles_table.php
@@ -9,7 +9,7 @@ class CreateCustomerProfilesTable extends Migration
      */
     public function up()
     {
-        Schema::table(config('cms.db-prefix', '').'user_meta', function ($table) {
+        Schema::table('user_meta', function ($table) {
             $table->string('stripe_id')->nullable();
             $table->string('card_brand')->nullable();
             $table->string('card_last_four')->nullable();


### PR DESCRIPTION
If I fix the class CreateUserMetaTable to use Schema::create(config('cms.db-prefix', '').'user_meta', function (Blueprint $table) {
I will go on this issue:

In UserService.php line 176:
              
  We were unable to generate your profile, please try again later.  

The fix from this commit make's a perfect 
php artisan migrate:fresh --seed